### PR TITLE
feat: compensation and reporting structure APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+build/
+.gradle/

--- a/NOTES.MD
+++ b/NOTES.MD
@@ -1,0 +1,21 @@
+# Task 1 Reporting Structure
+
+It seemed like using a database-side solution to calculate the total number of Direct Reports made the most sense.  With my limited knowledge of MongoDB, after looking at the documentation, `$graphLookup` seemed like the best option.  I started by setting up a local MongoDB with data to test out building the aggregation pipeline query.  After coming up with a query that worked, I started translating the native query into the sprint data compatible java code. After some trial and error, I ended up discovering my query worked against a standard MongoDB install, but not against the java embedded version.  After some research I swapped out `mongo-java-server` for `de.flapdoodle.embed:de.flapdoodle.embed.mongo` which does not have this issue.
+
+
+# Task 2 Compensation
+
+I Initially considered whether this new endpoint should return an employee's current compensation, or the history of their compensation.  Since it seems like returning historical compensation was more of a admin use case, I chose to implement only returning the employee's current compensation.  My next choice was whether this belonged in the `employee` collection or as a separate collection.  In a traditional RDBMS, this would be an extra table with `(user_id, salary, effective_date)` fields. However in a document store like MongoDB, it seems like the general advice is to include this sort of information in embedded documents.
+
+# Misc
+
+I **think** I discovered an existing bug with the "update employee" endpoint which would cause duplicate records to be created due to the absence of an annotated `@Id` on the `Employee` entity. The method in `AggregateRepository` probably should be in `EmployeeRepository` instead, but I could not determine how to refactor that interface into a concrete class while still allowing spring to auto-proxy the `findByEmployeeId` method. 
+
+This was built and tested against JDK13
+
+```
+$ java --version
+openjdk 13.0.14 2023-01-17
+OpenJDK Runtime Environment Zulu13.54+17-CA (build 13.0.14+5-MTS)
+OpenJDK 64-Bit Server VM Zulu13.54+17-CA (build 13.0.14+5-MTS, mixed mode)
+```

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,6 @@ dependencies {
 	implementation ('org.springframework.boot:spring-boot-starter-web')
 	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
 	testImplementation ('org.springframework.boot:spring-boot-starter-test')
-	implementation (group: 'de.bwaldvogel', name: 'mongo-java-server', version: '1.25.0')
+	// mongo-java-server (even latest) does not appear to support $graphLookup, so use embedded mongo instead
+	implementation('de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.9.2')
 }

--- a/src/main/java/com/mindex/challenge/controller/EmployeeController.java
+++ b/src/main/java/com/mindex/challenge/controller/EmployeeController.java
@@ -1,6 +1,9 @@
 package com.mindex.challenge.controller;
 
+import com.mindex.challenge.data.CompensationRequest;
+import com.mindex.challenge.data.CompensationResponseDto;
 import com.mindex.challenge.data.Employee;
+import com.mindex.challenge.data.ReportingStructure;
 import com.mindex.challenge.service.EmployeeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,16 +26,34 @@ public class EmployeeController {
 
     @GetMapping("/employee/{id}")
     public Employee read(@PathVariable String id) {
-        LOG.debug("Received employee create request for id [{}]", id);
+        LOG.debug("Received employee get request for id [{}]", id);
 
         return employeeService.read(id);
     }
 
+    @GetMapping("/employee/{id}/reporting")
+    public ReportingStructure getReportingStructure(@PathVariable String id){
+        LOG.debug("Received employee create request for id [{}]", id);
+
+        return employeeService.getReportingStructure(id);
+    }
+
     @PutMapping("/employee/{id}")
     public Employee update(@PathVariable String id, @RequestBody Employee employee) {
-        LOG.debug("Received employee create request for id [{}] and employee [{}]", id, employee);
+        LOG.debug("Received employee update request for id [{}] and employee [{}]", id, employee);
 
         employee.setEmployeeId(id);
         return employeeService.update(employee);
+    }
+
+    @PutMapping("/employee/{id}/compensation")
+    public CompensationResponseDto addCompensation(@PathVariable String id, @RequestBody CompensationRequest comp){
+        Employee e = employeeService.addCompensation(id, comp);
+        return new CompensationResponseDto(e);
+    }
+    @GetMapping("/employee/{id}/compensation")
+    public CompensationResponseDto getCompensation(@PathVariable String id){
+        Employee e = employeeService.read(id);
+        return new CompensationResponseDto(e);
     }
 }

--- a/src/main/java/com/mindex/challenge/dao/AggregateRepository.java
+++ b/src/main/java/com/mindex/challenge/dao/AggregateRepository.java
@@ -1,0 +1,49 @@
+package com.mindex.challenge.dao;
+
+import com.mindex.challenge.data.Employee;
+import com.mindex.challenge.data.ReportingStructure;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GraphLookupOperation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Repository
+public class AggregateRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(AggregateRepository.class);
+    private final MongoTemplate mongoTemplate;
+
+    public AggregateRepository(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    private static final String EMPLOYEE_COLLECTION_NAME = "employee";
+    private static final String NUMBER_OF_REPORTS_FIELD = "numberOfReports";
+
+    public int getReportingStructure(String employeeId) {
+        MatchOperation matchOperation = Aggregation.match(new Criteria("employeeId").is(employeeId));
+        GraphLookupOperation graphLookup = Aggregation.graphLookup(EMPLOYEE_COLLECTION_NAME)
+                .startWith("$directReports.employeeId")
+                .connectFrom("directReports.employeeId")
+                .connectTo("employeeId")
+                .as("reportingHierarchy");
+
+        ProjectionOperation projectionOperation = Aggregation.project()
+                .and("reportingHierarchy").size().as(NUMBER_OF_REPORTS_FIELD);
+        Aggregation aggregation = Aggregation.newAggregation(matchOperation, graphLookup, projectionOperation);
+        Map map = mongoTemplate.aggregate(aggregation, EMPLOYEE_COLLECTION_NAME, Map.class).getUniqueMappedResult();
+        int numberOfReports = 0;
+        if (map != null && map.containsKey(NUMBER_OF_REPORTS_FIELD)) {
+            numberOfReports = (Integer) map.get(NUMBER_OF_REPORTS_FIELD);
+        }
+        return numberOfReports;
+    }
+}

--- a/src/main/java/com/mindex/challenge/data/Compensation.java
+++ b/src/main/java/com/mindex/challenge/data/Compensation.java
@@ -1,0 +1,28 @@
+package com.mindex.challenge.data;
+
+import java.util.Date;
+
+public class Compensation {
+    private double salary;
+    private Date effectiveDate;
+    public Compensation(double salary, Date effectiveDate) {
+        this.salary = salary;
+        this.effectiveDate = effectiveDate;
+    }
+
+    public double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(double salary) {
+        this.salary = salary;
+    }
+
+    public Date getEffectiveDate() {
+        return effectiveDate;
+    }
+
+    public void setEffectiveDate(Date effectiveDate) {
+        this.effectiveDate = effectiveDate;
+    }
+}

--- a/src/main/java/com/mindex/challenge/data/CompensationRequest.java
+++ b/src/main/java/com/mindex/challenge/data/CompensationRequest.java
@@ -1,0 +1,29 @@
+package com.mindex.challenge.data;
+
+import java.util.Date;
+
+public class CompensationRequest {
+    private double salary;
+    private Date effectiveDate;
+    public CompensationRequest() {}
+    public CompensationRequest(double salary, Date effectiveDate) {
+        this.salary = salary;
+        this.effectiveDate = effectiveDate;
+    }
+
+    public double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(double salary) {
+        this.salary = salary;
+    }
+
+    public Date getEffectiveDate() {
+        return effectiveDate;
+    }
+
+    public void setEffectiveDate(Date effectiveDate) {
+        this.effectiveDate = effectiveDate;
+    }
+}

--- a/src/main/java/com/mindex/challenge/data/CompensationResponseDto.java
+++ b/src/main/java/com/mindex/challenge/data/CompensationResponseDto.java
@@ -1,0 +1,47 @@
+package com.mindex.challenge.data;
+
+import java.util.Comparator;
+import java.util.Date;
+
+public class CompensationResponseDto {
+    private Employee employee;
+    private double salary;
+    private Date effectiveDate;
+    public CompensationResponseDto() {}
+    public CompensationResponseDto(Employee e) {
+        this.employee = e;
+        if (e.getCompensation() != null && e.getCompensation().size() > 0) {
+            // sort the compensations by effective date, latest first
+            e.getCompensation().sort((c1, c2) -> c2.getEffectiveDate().compareTo(c1.getEffectiveDate()));
+            // get the most recent compensation that is not in the future
+            e.getCompensation().stream().filter(c -> c.getEffectiveDate().before(new Date())).findFirst().ifPresent(c -> {
+                this.salary = c.getSalary();
+                this.effectiveDate = c.getEffectiveDate();
+            });
+        }
+    }
+
+    public Employee getEmployee() {
+        return employee;
+    }
+
+    public void setEmployee(Employee employee) {
+        this.employee = employee;
+    }
+
+    public double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(double salary) {
+        this.salary = salary;
+    }
+
+    public Date getEffectiveDate() {
+        return effectiveDate;
+    }
+
+    public void setEffectiveDate(Date effectiveDate) {
+        this.effectiveDate = effectiveDate;
+    }
+}

--- a/src/main/java/com/mindex/challenge/data/Employee.java
+++ b/src/main/java/com/mindex/challenge/data/Employee.java
@@ -1,14 +1,25 @@
 package com.mindex.challenge.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.data.annotation.Id;
+
 import java.util.List;
 
 public class Employee {
+    // Without this Spring Data will create duplicate records when we just try to update the existing ones
+    // if we add @Id to employeeId, the underlying collection schema changes (employeeId becomes _id in the schema)
+    @Id
+    @JsonIgnore
+    private String id;
     private String employeeId;
     private String firstName;
     private String lastName;
     private String position;
     private String department;
     private List<Employee> directReports;
+
+    @JsonIgnore
+    private List<Compensation> compensation;
 
     public Employee() {
     }
@@ -59,5 +70,13 @@ public class Employee {
 
     public void setDirectReports(List<Employee> directReports) {
         this.directReports = directReports;
+    }
+
+    public List<Compensation> getCompensation() {
+        return compensation;
+    }
+
+    public void setCompensation(List<Compensation> compensation) {
+        this.compensation = compensation;
     }
 }

--- a/src/main/java/com/mindex/challenge/data/ReportingStructure.java
+++ b/src/main/java/com/mindex/challenge/data/ReportingStructure.java
@@ -1,0 +1,43 @@
+package com.mindex.challenge.data;
+
+import jdk.nashorn.internal.objects.annotations.Getter;
+
+public class ReportingStructure {
+
+    private Employee employee;
+
+    private int numberOfReports;
+    public ReportingStructure() {
+
+    }
+    public ReportingStructure(Employee employee, int numberOfReports) {
+        this.employee = employee;
+        this.numberOfReports = numberOfReports;
+
+    }
+
+    public Employee getEmployee() {
+        return employee;
+    }
+
+    public void setEmployee(Employee employee) {
+        this.employee = employee;
+    }
+
+    public int getNumberOfReports() {
+        return numberOfReports;
+    }
+
+    public void setNumberOfReports(int numberOfReports) {
+        this.numberOfReports = numberOfReports;
+    }
+
+
+    @Override
+    public String toString() {
+        return "ReportingStructure{" +
+                "employee=" + (employee == null ? null : employee.getEmployeeId()) +
+                ", numberOfReports=" + numberOfReports +
+                '}';
+    }
+}

--- a/src/main/java/com/mindex/challenge/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/mindex/challenge/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.mindex.challenge.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource not found")
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/mindex/challenge/service/EmployeeService.java
+++ b/src/main/java/com/mindex/challenge/service/EmployeeService.java
@@ -1,9 +1,15 @@
 package com.mindex.challenge.service;
 
+import com.mindex.challenge.data.CompensationRequest;
 import com.mindex.challenge.data.Employee;
+import com.mindex.challenge.data.ReportingStructure;
 
 public interface EmployeeService {
     Employee create(Employee employee);
     Employee read(String id);
     Employee update(Employee employee);
+
+    ReportingStructure getReportingStructure(String employeeId);
+
+    Employee addCompensation(String id, CompensationRequest comp);
 }

--- a/src/main/java/com/mindex/challenge/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/mindex/challenge/service/impl/EmployeeServiceImpl.java
@@ -1,12 +1,20 @@
 package com.mindex.challenge.service.impl;
 
+import com.mindex.challenge.dao.AggregateRepository;
+import com.mindex.challenge.data.Compensation;
+import com.mindex.challenge.data.CompensationRequest;
+import org.bson.Document;
 import com.mindex.challenge.dao.EmployeeRepository;
 import com.mindex.challenge.data.Employee;
+import com.mindex.challenge.data.ReportingStructure;
+import com.mindex.challenge.exception.ResourceNotFoundException;
 import com.mindex.challenge.service.EmployeeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
 import java.util.UUID;
 
 @Service
@@ -16,6 +24,8 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Autowired
     private EmployeeRepository employeeRepository;
+    @Autowired
+    private AggregateRepository aggregateRepository;
 
     @Override
     public Employee create(Employee employee) {
@@ -29,7 +39,7 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Override
     public Employee read(String id) {
-        LOG.debug("Creating employee with id [{}]", id);
+        LOG.debug("Fetching employee with id [{}]", id);
 
         Employee employee = employeeRepository.findByEmployeeId(id);
 
@@ -38,6 +48,42 @@ public class EmployeeServiceImpl implements EmployeeService {
         }
 
         return employee;
+    }
+
+    @Override
+    public ReportingStructure getReportingStructure(String employeeId) {
+        LOG.debug("Fetching reporting structure for employee with id [{}]", employeeId);
+
+        Employee employee = employeeRepository.findByEmployeeId(employeeId);
+
+        if (employee == null) {
+            throw new ResourceNotFoundException("Invalid employeeId: " + employeeId);
+        }
+
+        int numberOfReports = 0;
+        // if there are no direct reports then there's no need to try and query the total number of reports
+        if(employee.getDirectReports() != null && employee.getDirectReports().size() > 0) {
+            numberOfReports = aggregateRepository.getReportingStructure(employeeId);
+        }
+        return new ReportingStructure(employee, numberOfReports);
+    }
+
+    @Override
+    public Employee addCompensation(String employeeId, CompensationRequest compRequest) {
+        LOG.debug("Updating employee employee compensation [{}]", employeeId);
+        Employee employee = employeeRepository.findByEmployeeId(employeeId);
+
+        if (employee == null) {
+            throw new ResourceNotFoundException("Invalid employeeId: " + employeeId);
+        }
+        Compensation compensation = new Compensation(compRequest.getSalary(), compRequest.getEffectiveDate());
+        if(employee.getCompensation() == null) {
+            employee.setCompensation(Arrays.asList(compensation));
+        } else{
+            employee.getCompensation().add(compensation);
+        }
+
+        return employeeRepository.save(employee);
     }
 
     @Override

--- a/src/main/resources/static/employee_database.json
+++ b/src/main/resources/static/employee_database.json
@@ -48,6 +48,18 @@
     "firstName" : "George",
     "lastName" : "Harrison",
     "position" : "Developer III",
-    "department" : "Engineering"
+    "department" : "Engineering",
+    "directReports" : [
+      {
+        "employeeId": "e7ce7a26-bfc6-431b-900f-7098acfa0f5e"
+      }
+    ]
+  },
+  {
+    "employeeId" : "e7ce7a26-bfc6-431b-900f-7098acfa0f5e",
+    "firstName" : "Yoko",
+    "lastName" : "Ono",
+    "position" : "???",
+    "department" : "Marketing"
   }
 ]

--- a/src/test/java/com/mindex/challenge/DataBootstrapTest.java
+++ b/src/test/java/com/mindex/challenge/DataBootstrapTest.java
@@ -26,5 +26,6 @@ public class DataBootstrapTest {
         assertEquals("Lennon", employee.getLastName());
         assertEquals("Development Manager", employee.getPosition());
         assertEquals("Engineering", employee.getDepartment());
+        assertEquals(2, employee.getDirectReports().size());
     }
 }

--- a/src/test/java/com/mindex/challenge/dao/AggregateRepositoryTest.java
+++ b/src/test/java/com/mindex/challenge/dao/AggregateRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.mindex.challenge.dao;
+
+import com.mindex.challenge.data.ReportingStructure;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class AggregateRepositoryTest {
+    private static final String TOP_LEVEL_EMPLOYEE_ID = "16a596ae-edd3-4847-99fe-c4518e82c86f";
+    private static final String SINGLE_LEVEL_REPORT_EMPLOYEE_ID = "c0c2293d-16bd-4603-8e08-638a9d18b22c";
+    private static final String NESTED_EMPLOYEE_ID = "b7839309-3348-463b-a7e3-5de1c168beb3";
+    @Autowired
+    private AggregateRepository aggregateRepository;
+
+    @Autowired
+    private EmployeeRepository employeeRepo;
+    @Test
+    public void testGetReportingStructureRecursive() {
+        int numberOfReports = aggregateRepository.getReportingStructure(TOP_LEVEL_EMPLOYEE_ID);
+        assertEquals(5, numberOfReports);
+    }
+    @Test
+    public void testGetReportingStructureSingleLayer() {
+        int numberOfReports = aggregateRepository.getReportingStructure(SINGLE_LEVEL_REPORT_EMPLOYEE_ID);
+        assertEquals(1, numberOfReports);
+    }
+    @Test
+    public void testGetReportingStructureZeroReports() {
+        int zeroReports = aggregateRepository.getReportingStructure(NESTED_EMPLOYEE_ID);
+        assertEquals(0, zeroReports);
+    }
+}

--- a/src/test/java/com/mindex/challenge/service/impl/EmployeeServiceImplTest.java
+++ b/src/test/java/com/mindex/challenge/service/impl/EmployeeServiceImplTest.java
@@ -1,6 +1,9 @@
 package com.mindex.challenge.service.impl;
 
+import com.mindex.challenge.data.CompensationRequest;
+import com.mindex.challenge.data.CompensationResponseDto;
 import com.mindex.challenge.data.Employee;
+import com.mindex.challenge.data.ReportingStructure;
 import com.mindex.challenge.service.EmployeeService;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,15 +18,20 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Date;
+import java.util.GregorianCalendar;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class EmployeeServiceImplTest {
-
+    private static final String TOP_LEVEL_EMPLOYEE_ID = "16a596ae-edd3-4847-99fe-c4518e82c86f";
     private String employeeUrl;
     private String employeeIdUrl;
+    private String reportingStructureUrl;
+    private String compensationUrl;
 
     @Autowired
     private EmployeeService employeeService;
@@ -38,6 +46,8 @@ public class EmployeeServiceImplTest {
     public void setup() {
         employeeUrl = "http://localhost:" + port + "/employee";
         employeeIdUrl = "http://localhost:" + port + "/employee/{id}";
+        reportingStructureUrl = "http://localhost:" + port + "/employee/{id}/reporting";
+        compensationUrl =  "http://localhost:" + port + "/employee/{id}/compensation";
     }
 
     @Test
@@ -76,6 +86,79 @@ public class EmployeeServiceImplTest {
 
         assertEmployeeEquivalence(readEmployee, updatedEmployee);
     }
+
+    @Test
+    public void testGetReportingStructure() {
+        ReportingStructure structure = restTemplate.getForEntity(reportingStructureUrl, ReportingStructure.class, TOP_LEVEL_EMPLOYEE_ID).getBody();
+        assertEquals(TOP_LEVEL_EMPLOYEE_ID, structure.getEmployee().getEmployeeId());
+        assertEquals(5, structure.getNumberOfReports());
+    }
+
+    @Test
+    public void testCreateReadUpdateCompensation(){
+        // setup
+        Employee testEmployee = new Employee();
+        testEmployee.setFirstName("John");
+        testEmployee.setLastName("Doe");
+        testEmployee.setDepartment("Engineering");
+        testEmployee.setPosition("Developer");
+
+        // Create checks
+        Employee createdEmployee = restTemplate.postForEntity(employeeUrl, testEmployee, Employee.class).getBody();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Date d = new GregorianCalendar(2010, 01, 01).getTime();
+        CompensationRequest request = new CompensationRequest(123, d);
+
+        CompensationResponseDto comp =
+                restTemplate.exchange(compensationUrl,
+                        HttpMethod.PUT,
+                        new HttpEntity<>(request, headers),
+                        CompensationResponseDto.class,
+                        createdEmployee.getEmployeeId()).getBody();
+
+        assertEquals(123, comp.getSalary(), 0.001);
+        assertEquals(d, comp.getEffectiveDate());
+        assertEquals(createdEmployee.getEmployeeId(),comp.getEmployee().getEmployeeId());
+
+        // Test Get
+        comp = restTemplate.getForEntity(compensationUrl, CompensationResponseDto.class, createdEmployee.getEmployeeId()).getBody();
+        assertEquals(123, comp.getSalary(), 0.001);
+        assertEquals(d, comp.getEffectiveDate());
+        assertEquals(createdEmployee.getEmployeeId(),comp.getEmployee().getEmployeeId());
+
+        // update again and make sure the comp is reflected
+        d = new GregorianCalendar(2020, 01, 01).getTime();
+        request = new CompensationRequest(150, d);
+
+        comp =
+                restTemplate.exchange(compensationUrl,
+                        HttpMethod.PUT,
+                        new HttpEntity<>(request, headers),
+                        CompensationResponseDto.class,
+                        createdEmployee.getEmployeeId()).getBody();
+
+        assertEquals(150, comp.getSalary(), 0.001);
+        assertEquals(d, comp.getEffectiveDate());
+        assertEquals(createdEmployee.getEmployeeId(),comp.getEmployee().getEmployeeId());
+
+        // set future compensation change and verify it does not appear as their current compensation
+        Date futureCompDate = new GregorianCalendar(2023, 11, 01).getTime();
+        request = new CompensationRequest(200, d);
+
+        comp =
+                restTemplate.exchange(compensationUrl,
+                        HttpMethod.PUT,
+                        new HttpEntity<>(request, headers),
+                        CompensationResponseDto.class,
+                        createdEmployee.getEmployeeId()).getBody();
+
+        // current comp, not future comp
+        assertEquals(150, comp.getSalary(), 0.001);
+        assertEquals(d, comp.getEffectiveDate());
+        assertEquals(createdEmployee.getEmployeeId(),comp.getEmployee().getEmployeeId());
+    }
+
 
     private static void assertEmployeeEquivalence(Employee expected, Employee actual) {
         assertEquals(expected.getFirstName(), actual.getFirstName());


### PR DESCRIPTION
- add reporting structure endpoint calculated using mongo's `$graphLookoup`
  - Added extra employee to static data to more easily test all cases
  - swap out embedded mongo to deal with `$graphLookup` inconsistencies.
- add compensation add / get endpoints
- add explicit generated field for mongo's _id to allow save/updates to function correctly Please enter the commit message for your changes. Lines starting